### PR TITLE
Remove console.logs revealing other players' cards

### DIFF
--- a/coup-client/src/components/game/Coup.js
+++ b/coup-client/src/components/game/Coup.js
@@ -58,7 +58,6 @@ export default class Coup extends Component {
             bind.setState({playAgain: null})
             bind.setState({winner: null})
             players = players.filter(x => !x.isDead);
-            console.log(players)
             let playerIndex = null;
             for(let i = 0; i < players.length; i++) {
                 console.log(players[i].name, this.props.name)
@@ -101,9 +100,7 @@ export default class Coup extends Component {
             }
             bind.setState({logs :bind.state.logs})
         })
-        this.props.socket.on('g-chooseAction', () => {
-            console.log(this.state.players, this.state.playerIndex)
-        
+        this.props.socket.on('g-chooseAction', () => {        
             bind.setState({ isChooseAction: true})
         });
         this.props.socket.on('g-openExchange', (drawTwo) => {


### PR DESCRIPTION
### Background

It is possible to view all of the other players' cards by simply opening the browser's console, which can be unfair.
Example: the current screen is visible by user `join` and they can see not only their cards but the other player's (`main`) cards

![Screen Shot 2020-11-27 at 2 16 37 PM](https://user-images.githubusercontent.com/14348784/100479202-7d0db500-30bb-11eb-98d7-e9978c948957.png)

### Solution

Delete all `console.log` statements printing player information.

Am I missing some places?
