### PR TITLE
Fix bug where Contessa is always allocated to 1st player

### DIFF
--- a/server/game/utils.js
+++ b/server/game/utils.js
@@ -6,13 +6,12 @@ buildDeck = () => {
     for (let card of cardNames) {
         addToDeck(card, deck);
     }
-    for(let i = 0; i < deck.length*2; i++) {
-        const one = Math.floor(Math.random()*(deck.length-1));
-        const two = Math.floor(Math.random()*(deck.length-1));
-        let temp = deck[one];
-        deck[one] = deck[two];
-        deck[two] = temp;
-    }
+
+    deck = deck
+        .map((value) => ({ value, sort: Math.random() }))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ value }) => value);
+
     return deck;
 }
 


### PR DESCRIPTION
This fixes #37.

In playing with the app, I found the same issue as described in #37. Essentially, it seems like the first user's first card will always be the Contessa. I think this is a bug in the shuffle loop.

I've swapped this to use a Schwartzian transform, which is quite functional. For the small size of the deck, this should be fine.