### PR TITLE
fix: prevent failing challenges with incorrect character claiming to block steal

### DIFF
--- a/coup-client/src/components/game/BlockDecision.js
+++ b/coup-client/src/components/game/BlockDecision.js
@@ -83,15 +83,15 @@ export default class BlockDecision extends Component {
                 <button onClick={() => this.block('block_foreign_aid')}>Block Foreign Aid</button>
                 </>
             } else if(this.props.action.action === 'steal') {
-                control = <button onClick={() => this.pickClaim('block_steal')}>Block Steal</button>
+                control = <button onClick={() => this.pickClaim('block_steal_with_')}>Block Steal</button>
             } else if(this.props.action.action === 'assassinate') {
                 control = <button onClick={() => this.block('block_assassinate')}>Block Assassination</button>
             }
         } else {
             pickClaim = <>
                 <p>To block steal, do you claim Ambassador or Captain?</p>
-                <button onClick={() => this.block(this.state.decision, 'ambassador')}>Ambassador</button>
-                <button onClick={() => this.block(this.state.decision, 'captain')}>Captain</button>
+                <button onClick={() => this.block(this.state.decision+'ambassador', 'ambassador')}>Ambassador</button>
+                <button onClick={() => this.block(this.state.decision+'captain', 'captain')}>Captain</button>
             </>
         }
         

--- a/coup-client/src/components/game/RevealDecision.js
+++ b/coup-client/src/components/game/RevealDecision.js
@@ -12,7 +12,8 @@ export default class RevealDecision extends Component {
             exchange: ["ambassador"],
             steal: ["captain"],
             block_foreign_aid: ["duke"],
-            block_steal: ["ambassador", "captain"],
+            block_steal_with_ambassador: ["ambassador"],
+            block_steal_with_captain: ["captain"],
             block_assassinate: ["contessa"],
         }
     }

--- a/server/game/coup.js
+++ b/server/game/coup.js
@@ -134,7 +134,7 @@ class CoupGame{
                 if(bind.isRevealOpen) {
                     bind.isRevealOpen = false;
                     if(res.isBlock) { //block challenge (for example, a captain blocking a steal or a contessa blocking an assasinate)
-                        if(res.revealedCard == res.counterAction.claim || (res.counterAction.counterAction == 'block_steal' && (res.revealedCard == 'ambassador' || res.revealedCard =='captain'))) { //challenge failed
+                        if(res.revealedCard == res.counterAction.claim) { //challenge failed
                             bind.gameSocket.emit("g-addLog", `${res.challenger}'s challenge on ${res.challengee}'s block failed`)
                             for(let i = 0; i < bind.players[challengeeIndex].influences.length; i++) { //revealed card needs to be replaced
                                 if(bind.players[challengeeIndex].influences[i] == res.revealedCard) {

--- a/server/utilities/constants.js
+++ b/server/utilities/constants.js
@@ -58,8 +58,11 @@ const CounterActions = {
     block_foreign_aid: {
         influences: [CardNames.DUKE]
     },
-    block_steal: {
-        influences: [CardNames.AMBASSADOR, CardNames.CAPTAIN]
+    block_steal_with_ambassador: {
+        influences: [CardNames.AMBASSADOR]
+    },
+    block_steal_with_captain: {
+        influences: [CardNames.CAPTAIN]
     },
     block_assassinate: {
         influences: [CardNames.CONTESSA]


### PR DESCRIPTION
fixes a game logic issue that contradicts the rule of the game
for example
A tries to steal from B
B have captain and duke
B blocks stealing but claiming to block with ambassador (intentionally or misclicks)
A challenges the block
in the current state of the game the challenge can fail if B chooses to reveal captain when in the real card game B has to reveal ambassador to fail the challenge
this pr fixes this by splitting the block steal counter action into 2 instead
i've tested all the cases this could affect
 - blocking steal with captain but having ambassador then reveal ambassador (or other character apart from captain) -> challenge succeed
 - blocking steal with ambassador but having captain then reveal captain (or other character apart from ambassador) -> challenge succeed
 - blocking steal with captain/ambassador while not having either -> challenge succeed
 - blocking steal with captain while having captain then reveal captain -> challenge fails
 - blocking steal with ambassador while having ambassador -> challenge fails